### PR TITLE
ci: Linux-native DocC + GitHub Pages deploy

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -1,4 +1,4 @@
-name: DocC
+name: DocC -> GitHub Pages
 
 on:
   push:
@@ -10,27 +10,66 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
-  docc:
+  build-docs:
     name: Build documentation
-    runs-on: macos-15
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.app
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.1"
 
-      # Uses xcodebuild docbuild — no swift-docc-plugin dependency required.
-      # Xcode auto-discovers the SPM package and builds documentation for
-      # the SwiftXMLCoder scheme.
-      - name: Build DocC
+      - name: Install system dependencies
         run: |
-          xcodebuild docbuild \
-            -scheme SwiftXMLCoder \
-            -destination "generic/platform=macOS" \
-            -derivedDataPath /tmp/docc-build \
-            | xcpretty || true
-          # Verify the .doccarchive was produced
-          find /tmp/docc-build -name "SwiftXMLCoder.doccarchive" | grep -q . \
-            && echo "DocC archive produced ✓" \
-            || (echo "DocC archive missing ✗" && exit 1)
+          sudo apt-get update
+          sudo apt-get install -y libxml2-dev
+
+      # Emit symbol graphs into the release build output directory.
+      # docc searches the directory recursively for *.symbols.json files.
+      - name: Build (emit symbol graphs)
+        run: |
+          swift build -c release \
+            -Xswiftc -emit-symbol-graph \
+            -Xswiftc -symbol-graph-minimum-access-level \
+            -Xswiftc public
+
+      # Convert the .docc catalog + symbol graphs to a static website.
+      # --hosting-base-path must match the GitHub Pages sub-path
+      # (i.e. the repository name).
+      - name: Convert to static site
+        run: |
+          docc convert Sources/SwiftXMLCoder/SwiftXMLCoder.docc \
+            --fallback-display-name SwiftXMLCoder \
+            --fallback-bundle-identifier io.github.MFranceschi6.swift-xml-coder \
+            --additional-symbol-graph-dir .build/release \
+            --output-path ./docs \
+            --transform-for-static-hosting \
+            --hosting-base-path swift-xml-coder
+
+      # Only upload the Pages artifact on push to main (not on PRs).
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+
+  deploy-pages:
+    name: Deploy to GitHub Pages
+    needs: build-docs
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Riscrive `docc.yml` usando la CLI `docc` inclusa nel toolchain Swift 6.1 su `ubuntu-22.04` — nessuna dipendenza SPM aggiunta
- Rimuove `xcodebuild docbuild` (macOS/Xcode-only, runner costosi)
- Aggiunge il job `deploy-pages` che pubblica il sito statico su GitHub Pages ad ogni merge su `main`

**URL finale:** https://mfranceschi6.github.io/swift-xml-coder/

## Flusso

| Evento | `build-docs` | `deploy-pages` |
|--------|-------------|----------------|
| PR aperta | ✅ build + convert | ❌ skip |
| Merge su `main` | ✅ build + convert + upload artifact | ✅ deploy |

## Requisito manuale

Abilitare **Settings → Pages → Source → "GitHub Actions"** sul repo prima del merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)